### PR TITLE
Use short gem key for GitHub Packages [skip ci]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,8 @@ jobs:
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:github_packages_api_key: Bearer ${{ secrets.GITHUB_TOKEN }}\n" > $HOME/.gem/credentials
+          printf -- "---\n:github: Bearer ${{ secrets.GITHUB_TOKEN }}\n" > $HOME/.gem/credentials
       - run: bundle exec rake release
         env:
-          BUNDLE_GEM__PUSH_KEY: github_packages_api_key
+          BUNDLE_GEM__PUSH_KEY: github
           RUBYGEMS_HOST: "https://rubygems.pkg.github.com/${{ github.repository_owner }}"


### PR DESCRIPTION
Consistent with their various documentation:

- https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby#publishing-gems
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry
